### PR TITLE
Fix create user typo

### DIFF
--- a/internal/bot/middleware/load_user_language.go
+++ b/internal/bot/middleware/load_user_language.go
@@ -36,7 +36,7 @@ func LoadUserLanguage(appCore *core.Core) tb.MiddlewareFunc {
 						ID: userID,
 						// LanguageCode will be set to 'en' by default in DB (due to model tag)
 					}
-					// appCore.CreateUser calls storage.CrateUser
+					// appCore.CreateUser ultimately calls storage.CreateUser
 					if createErr := appCore.CreateUser(context.Background(), newUser); createErr != nil {
 						log.Errorf("Failed to create user %d: %v", userID, createErr)
 						// Even if creation fails, set a default lang and continue
@@ -51,17 +51,17 @@ func LoadUserLanguage(appCore *core.Core) tb.MiddlewareFunc {
 					c.Set(util.UserLanguageKey, util.DefaultLanguage) // Safest to set 'en' as it's the default
 					return next(c)
 				}
-				
+
 				log.Errorf("Failed to get user %d: %v. Using default language.", userID, err)
 				c.Set(util.UserLanguageKey, util.DefaultLanguage)
 				return next(c)
 			}
 
 			if user.LanguageCode == "" {
-				 log.Warnf("User %d has empty LanguageCode, defaulting to 'en'. Consider updating user record.", userID)
-				 c.Set(util.UserLanguageKey, util.DefaultLanguage)
+				log.Warnf("User %d has empty LanguageCode, defaulting to 'en'. Consider updating user record.", userID)
+				c.Set(util.UserLanguageKey, util.DefaultLanguage)
 			} else {
-				 c.Set(util.UserLanguageKey, user.LanguageCode)
+				c.Set(util.UserLanguageKey, user.LanguageCode)
 			}
 			return next(c)
 		}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -496,13 +496,11 @@ func (c *Core) GetUser(ctx context.Context, id int64) (*model.User, error) {
 	return user, nil
 }
 
-// Assuming CrateUser in userStorage was a typo and should be CreateUser.
-// If userStorage.CrateUser must be kept, change the call accordingly.
 func (c *Core) CreateUser(ctx context.Context, user *model.User) error {
 	// It's possible that GetUser is called first, and if not found, then CreateUser is called.
 	// Ensure the user object passed in has the ID set.
 	// The LanguageCode will default to 'en' due to the model's GORM tag.
-	return c.userStorage.CrateUser(ctx, user) // Use CrateUser to match existing storage method name
+	return c.userStorage.CreateUser(ctx, user)
 }
 
 func (c *Core) SetUserLanguage(ctx context.Context, userID int64, langCode string) error {

--- a/internal/storage/mock/storage_mock.go
+++ b/internal/storage/mock/storage_mock.go
@@ -73,18 +73,18 @@ func (m *MockUser) EXPECT() *MockUserMockRecorder {
 	return m.recorder
 }
 
-// CrateUser mocks base method.
-func (m *MockUser) CrateUser(ctx context.Context, user *model.User) error {
+// CreateUser mocks base method.
+func (m *MockUser) CreateUser(ctx context.Context, user *model.User) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CrateUser", ctx, user)
+	ret := m.ctrl.Call(m, "CreateUser", ctx, user)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CrateUser indicates an expected call of CrateUser.
-func (mr *MockUserMockRecorder) CrateUser(ctx, user interface{}) *gomock.Call {
+// CreateUser indicates an expected call of CreateUser.
+func (mr *MockUserMockRecorder) CreateUser(ctx, user interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CrateUser", reflect.TypeOf((*MockUser)(nil).CrateUser), ctx, user)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockUser)(nil).CreateUser), ctx, user)
 }
 
 // GetUser mocks base method.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -21,7 +21,7 @@ type Storage interface {
 // User 用户存储接口
 type User interface {
 	Storage
-	CrateUser(ctx context.Context, user *model.User) error
+	CreateUser(ctx context.Context, user *model.User) error
 	GetUser(ctx context.Context, id int64) (*model.User, error)
 	SetUserLanguage(ctx context.Context, userID int64, langCode string) error
 }

--- a/internal/storage/user.go
+++ b/internal/storage/user.go
@@ -21,7 +21,7 @@ func (s *UserStorageImpl) Init(ctx context.Context) error {
 	return s.db.Migrator().AutoMigrate(&model.User{})
 }
 
-func (s *UserStorageImpl) CrateUser(ctx context.Context, user *model.User) error {
+func (s *UserStorageImpl) CreateUser(ctx context.Context, user *model.User) error {
 	result := s.db.WithContext(ctx).Create(user)
 	if result.Error != nil {
 		return result.Error

--- a/internal/storage/user_test.go
+++ b/internal/storage/user_test.go
@@ -31,7 +31,7 @@ func TestUserStorageImpl(t *testing.T) {
 
 	t.Run(
 		"save user", func(t *testing.T) {
-			err := s.CrateUser(ctx, user)
+			err := s.CreateUser(ctx, user)
 			assert.Nil(t, err)
 		},
 	)


### PR DESCRIPTION
## Summary
- rename `CrateUser` to `CreateUser` in storage interface and implementations
- update core logic, middleware comments and tests for new method

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f800965a88322bef4fc59cbd4f2f4