### PR TITLE
Build Docker image on merge

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,32 @@
+name: Build Docker Image
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build-and-push:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: "zintus/flowerss-bot:latest,zintus/flowerss-bot:${{ github.event.pull_request.merge_commit_sha }}"


### PR DESCRIPTION
## Summary
- add GitHub action to build Docker image and push to Docker Hub when a PR is merged to main
- use Docker Hub access token for authentication

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f802a046c8322a40bcf797d573b23