### PR TITLE
Sort subscriptions by last published date

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -38,7 +38,9 @@
       "Bash(/usr/bin/git commit:*)",
       "Bash(/usr/bin/git push:*)",
       "Bash(/usr/bin/git log --oneline -10)",
-      "Bash(/usr/bin/git add go.mod go.sum)"
+      "Bash(/usr/bin/git add go.mod go.sum)",
+      "Bash(git checkout:*)",
+      "Bash(gh:*)"
     ],
     "deny": []
   },

--- a/internal/bot/handler/list_subscription_test.go
+++ b/internal/bot/handler/list_subscription_test.go
@@ -1,0 +1,278 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	tb "gopkg.in/telebot.v3"
+
+	"github.com/zintus/flowerss-bot/internal/bot/util"
+	"github.com/zintus/flowerss-bot/internal/core"
+	"github.com/zintus/flowerss-bot/internal/model"
+	"github.com/zintus/flowerss-bot/internal/storage"
+)
+
+type mockListSubCtx struct {
+	tb.Context
+	sentMessages []string
+}
+
+func (m *mockListSubCtx) Send(what interface{}, opts ...interface{}) error {
+	if s, ok := what.(string); ok {
+		m.sentMessages = append(m.sentMessages, s)
+	}
+	return nil
+}
+
+type mockListSubSubscriptionStorage struct {
+	getUserSubsFunc func(ctx context.Context, userID int64, opts *storage.GetSubscriptionsOptions) (*storage.GetSubscriptionsResult, error)
+}
+
+func (m *mockListSubSubscriptionStorage) Init(ctx context.Context) error { return nil }
+
+func (m *mockListSubSubscriptionStorage) AddSubscription(ctx context.Context, sub *model.Subscribe) error {
+	panic("not implemented")
+}
+
+func (m *mockListSubSubscriptionStorage) SubscriptionExist(ctx context.Context, userID int64, sourceID uint) (bool, error) {
+	panic("not implemented")
+}
+
+func (m *mockListSubSubscriptionStorage) GetSubscription(ctx context.Context, userID int64, sourceID uint) (*model.Subscribe, error) {
+	panic("not implemented")
+}
+
+func (m *mockListSubSubscriptionStorage) GetSubscriptionsByUserID(ctx context.Context, userID int64, opts *storage.GetSubscriptionsOptions) (*storage.GetSubscriptionsResult, error) {
+	if m.getUserSubsFunc != nil {
+		return m.getUserSubsFunc(ctx, userID, opts)
+	}
+	return &storage.GetSubscriptionsResult{}, nil
+}
+
+func (m *mockListSubSubscriptionStorage) GetSubscriptionsBySourceID(ctx context.Context, sourceID uint, opts *storage.GetSubscriptionsOptions) (*storage.GetSubscriptionsResult, error) {
+	panic("not implemented")
+}
+
+func (m *mockListSubSubscriptionStorage) CountSubscriptions(ctx context.Context) (int64, error) {
+	panic("not implemented")
+}
+
+func (m *mockListSubSubscriptionStorage) DeleteSubscription(ctx context.Context, userID int64, sourceID uint) (int64, error) {
+	panic("not implemented")
+}
+
+func (m *mockListSubSubscriptionStorage) CountSourceSubscriptions(ctx context.Context, sourceID uint) (int64, error) {
+	panic("not implemented")
+}
+
+func (m *mockListSubSubscriptionStorage) UpdateSubscription(ctx context.Context, userID int64, sourceID uint, newSubscription *model.Subscribe) error {
+	panic("not implemented")
+}
+
+func (m *mockListSubSubscriptionStorage) UpsertSubscription(ctx context.Context, userID int64, sourceID uint, newSubscription *model.Subscribe) error {
+	panic("not implemented")
+}
+
+type mockListSubSourceStorage struct {
+	getSourceFunc func(ctx context.Context, id uint) (*model.Source, error)
+}
+
+func (m *mockListSubSourceStorage) Init(ctx context.Context) error { return nil }
+
+func (m *mockListSubSourceStorage) AddSource(ctx context.Context, source *model.Source) error {
+	panic("not implemented")
+}
+
+func (m *mockListSubSourceStorage) GetSource(ctx context.Context, id uint) (*model.Source, error) {
+	if m.getSourceFunc != nil {
+		return m.getSourceFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *mockListSubSourceStorage) GetSources(ctx context.Context) ([]*model.Source, error) {
+	panic("not implemented")
+}
+
+func (m *mockListSubSourceStorage) GetSourceByURL(ctx context.Context, url string) (*model.Source, error) {
+	panic("not implemented")
+}
+
+func (m *mockListSubSourceStorage) Delete(ctx context.Context, id uint) error { return nil }
+
+func (m *mockListSubSourceStorage) UpsertSource(ctx context.Context, sourceID uint, newSource *model.Source) error {
+	panic("not implemented")
+}
+
+func TestListSubscription_replaySubscribedSources_Sorted(t *testing.T) {
+	now := time.Now()
+	yesterday := now.Add(-24 * time.Hour)
+	twoDaysAgo := now.Add(-48 * time.Hour)
+
+	sources := map[uint]*model.Source{
+		1: {ID: 1, Title: "Feed C", Link: "http://example.com/c", LastPublishedAt: &yesterday},
+		2: {ID: 2, Title: "Feed A", Link: "http://example.com/a", LastPublishedAt: &now},
+		3: {ID: 3, Title: "Feed B", Link: "http://example.com/b", LastPublishedAt: &twoDaysAgo},
+		4: {ID: 4, Title: "Feed D", Link: "http://example.com/d", LastPublishedAt: nil}, // nil date
+	}
+
+	subscriptions := []*model.Subscribe{
+		{UserID: 123, SourceID: 1},
+		{UserID: 123, SourceID: 2},
+		{UserID: 123, SourceID: 3},
+		{UserID: 123, SourceID: 4},
+	}
+
+	sourceStorage := &mockListSubSourceStorage{
+		getSourceFunc: func(ctx context.Context, id uint) (*model.Source, error) {
+			if source, ok := sources[id]; ok {
+				return source, nil
+			}
+			return nil, storage.ErrRecordNotFound
+		},
+	}
+
+	subStorage := &mockListSubSubscriptionStorage{
+		getUserSubsFunc: func(ctx context.Context, userID int64, opts *storage.GetSubscriptionsOptions) (*storage.GetSubscriptionsResult, error) {
+			return &storage.GetSubscriptionsResult{
+				Subscriptions: subscriptions,
+			}, nil
+		},
+	}
+
+	coreInstance := core.NewCore(nil, nil, sourceStorage, subStorage, nil, nil)
+	h := NewListSubscription(coreInstance)
+
+	ctx := &mockListSubCtx{
+		Context: &fakeContext{
+			chatID: 123,
+			data:   map[string]interface{}{util.UserLanguageKey: "en"},
+		},
+		sentMessages: []string{},
+	}
+
+	err := h.Handle(ctx)
+	if err != nil {
+		t.Fatalf("Handle() returned error: %v", err)
+	}
+
+	if len(ctx.sentMessages) == 0 {
+		t.Fatal("Expected at least one message to be sent")
+	}
+
+	msg := ctx.sentMessages[0]
+	t.Logf("Received message: %s", msg)
+
+	// Expected order: Feed A (now), Feed C (yesterday), Feed B (twoDaysAgo), Feed D (nil)
+	expectedOrder := []string{
+		fmt.Sprintf("[[%d]] [%s](%s) - %s", 2, "Feed A", "http://example.com/a", now.Format("2006-01-02 15:04:05")),
+		fmt.Sprintf("[[%d]] [%s](%s) - %s", 1, "Feed C", "http://example.com/c", yesterday.Format("2006-01-02 15:04:05")),
+		fmt.Sprintf("[[%d]] [%s](%s) - %s", 3, "Feed B", "http://example.com/b", twoDaysAgo.Format("2006-01-02 15:04:05")),
+		fmt.Sprintf("[[%d]] [%s](%s) - N/A", 4, "Feed D", "http://example.com/d"),
+	}
+
+	// Check if the message contains the sorted feeds
+	for i, expectedLine := range expectedOrder {
+		if !strings.Contains(msg, expectedLine) {
+			t.Errorf("Message should contain line %d: %s", i, expectedLine)
+		}
+	}
+
+	// Verify the order of lines in the message
+	lines := strings.Split(msg, "\n")
+	// Find where the actual feed list starts (after the header)
+	startIdx := -1
+	for i, line := range lines {
+		if strings.Contains(line, "[[") {
+			startIdx = i
+			break
+		}
+	}
+	
+	if startIdx >= 0 && len(lines) > startIdx {
+		foundCount := 0
+		for i := startIdx; i < len(lines) && foundCount < len(expectedOrder); i++ {
+			line := strings.TrimSpace(lines[i])
+			if line == "" {
+				continue
+			}
+			// Check if this line matches the expected order
+			if strings.Contains(line, fmt.Sprintf("[[%d]]", []int{2, 1, 3, 4}[foundCount])) {
+				foundCount++
+			}
+		}
+		if foundCount != len(expectedOrder) {
+			t.Errorf("Expected to find all %d feeds in order, but found %d", len(expectedOrder), foundCount)
+		}
+	} else {
+		t.Error("Could not find feed list in the message")
+	}
+}
+
+func TestListSubscription_replaySubscribedSources_EmptyList(t *testing.T) {
+	sourceStorage := &mockListSubSourceStorage{}
+	subStorage := &mockListSubSubscriptionStorage{
+		getUserSubsFunc: func(ctx context.Context, userID int64, opts *storage.GetSubscriptionsOptions) (*storage.GetSubscriptionsResult, error) {
+			return &storage.GetSubscriptionsResult{
+				Subscriptions: []*model.Subscribe{},
+			}, nil
+		},
+	}
+
+	coreInstance := core.NewCore(nil, nil, sourceStorage, subStorage, nil, nil)
+	h := NewListSubscription(coreInstance)
+
+	ctx := &mockListSubCtx{
+		Context: &fakeContext{
+			chatID: 123,
+			data:   map[string]interface{}{util.UserLanguageKey: "en"},
+		},
+		sentMessages: []string{},
+	}
+
+	err := h.Handle(ctx)
+	if err != nil {
+		t.Fatalf("Handle() returned error: %v", err)
+	}
+
+	if len(ctx.sentMessages) == 0 {
+		t.Fatal("Expected at least one message to be sent")
+	}
+
+	msg := ctx.sentMessages[0]
+	// The actual translation key is "listsub_info_sub_list_empty" which translates to "Subscription list is empty."
+	// But since we're not loading translations in the test, we get the translation missing message
+	if !strings.Contains(msg, "listsub_info_sub_list_empty") {
+		t.Errorf("Expected empty list message key, got: %s", msg)
+	}
+}
+
+// Helper fake context for testing
+type fakeContext struct {
+	tb.Context
+	chatID int64
+	data   map[string]interface{}
+}
+
+func (f *fakeContext) Chat() *tb.Chat {
+	return &tb.Chat{ID: f.chatID, Type: tb.ChatPrivate}
+}
+
+func (f *fakeContext) Get(key string) interface{} {
+	return f.data[key]
+}
+
+func (f *fakeContext) Message() *tb.Message {
+	return &tb.Message{Chat: &tb.Chat{ID: f.chatID}}
+}
+
+func (f *fakeContext) Bot() *tb.Bot {
+	return &tb.Bot{}
+}
+
+func (f *fakeContext) Sender() *tb.User {
+	return &tb.User{ID: 123}
+}

--- a/internal/feed/parser.go
+++ b/internal/feed/parser.go
@@ -40,5 +40,16 @@ func (p *FeedParser) ParseFromURL(ctx context.Context, URL string) (*gofeed.Feed
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, errors.New(resp.Status)
 	}
-	return p.parser.Parse(resp.Body)
+	feed, err := p.parser.Parse(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	// Use UpdatedParsed if available, otherwise PublishedParsed
+	if feed.UpdatedParsed != nil {
+		return feed, nil
+	}
+	if feed.PublishedParsed != nil {
+		feed.UpdatedParsed = feed.PublishedParsed
+	}
+	return feed, nil
 }

--- a/internal/model/source.go
+++ b/internal/model/source.go
@@ -1,10 +1,13 @@
 package model
 
+import "time"
+
 type Source struct {
-	ID         uint `gorm:"primary_key;AUTO_INCREMENT"`
-	Link       string
-	Title      string
-	ErrorCount uint
-	Content    []Content
+	ID              uint `gorm:"primary_key;AUTO_INCREMENT"`
+	Link            string
+	Title           string
+	ErrorCount      uint
+	LastPublishedAt *time.Time
+	Content         []Content
 	EditTime
 }

--- a/internal/scheduler/rss.go
+++ b/internal/scheduler/rss.go
@@ -117,6 +117,12 @@ func (t *RssUpdateTask) getSourceNewContents(source *model.Source) ([]*model.Con
 		log.Errorf("failed to clear source error count: %v", clearErr)
 	}
 
+	if rssFeed.UpdatedParsed != nil {
+		if err := t.core.UpdateSourceLastPublishedAt(context.Background(), source.ID, rssFeed.UpdatedParsed); err != nil {
+			log.Errorf("failed to update source LastPublishedAt: %v", err)
+		}
+	}
+
 	newContents, err := t.saveNewContents(source, rssFeed.Items)
 	if err != nil {
 		return nil, err

--- a/internal/storage/source_migration_test.go
+++ b/internal/storage/source_migration_test.go
@@ -1,0 +1,178 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/zintus/flowerss-bot/internal/model"
+)
+
+func TestSourceStorage_Migration_AddsLastPublishedAt(t *testing.T) {
+	// Create an in-memory SQLite database
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+
+	// Create the sources table without LastPublishedAt (simulating old schema)
+	// We'll manually create the table via SQL
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get sql.DB: %v", err)
+	}
+
+	// Create old schema without LastPublishedAt
+	_, err = sqlDB.Exec(`
+		CREATE TABLE sources (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			link TEXT,
+			title TEXT,
+			error_count INTEGER,
+			created_at DATETIME,
+			updated_at DATETIME
+		)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to create old schema: %v", err)
+	}
+
+	// Insert test data
+	now := time.Now()
+	_, err = sqlDB.Exec(`
+		INSERT INTO sources (link, title, error_count, created_at, updated_at)
+		VALUES 
+			('http://example1.com/feed', 'Feed 1', 0, ?, ?),
+			('http://example2.com/feed', 'Feed 2', 1, ?, ?),
+			('http://example3.com/feed', 'Feed 3', 0, ?, ?)
+	`, now, now, now, now, now, now)
+	if err != nil {
+		t.Fatalf("Failed to insert test data: %v", err)
+	}
+
+	// Verify LastPublishedAt column doesn't exist
+	var columnCount int
+	err = sqlDB.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('sources')
+		WHERE name = 'last_published_at'
+	`).Scan(&columnCount)
+	if err != nil {
+		t.Fatalf("Failed to check column existence: %v", err)
+	}
+	if columnCount != 0 {
+		t.Fatal("last_published_at column should not exist in old schema")
+	}
+
+	// Run the migration
+	storage := NewSourceStorageImpl(db)
+	if err := storage.Init(context.Background()); err != nil {
+		t.Fatalf("Failed to run migration: %v", err)
+	}
+
+	// Verify LastPublishedAt column now exists
+	err = sqlDB.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('sources')
+		WHERE name = 'last_published_at'
+	`).Scan(&columnCount)
+	if err != nil {
+		t.Fatalf("Failed to check column existence after migration: %v", err)
+	}
+	if columnCount != 1 {
+		t.Fatal("last_published_at column should exist after migration")
+	}
+
+	// Verify we can query the data with the new model
+	var sources []*model.Source
+	if err := db.Find(&sources).Error; err != nil {
+		t.Fatalf("Failed to query sources after migration: %v", err)
+	}
+
+	if len(sources) != 3 {
+		t.Fatalf("Expected 3 sources, got %d", len(sources))
+	}
+
+	// Verify all existing sources have nil LastPublishedAt
+	for _, src := range sources {
+		if src.LastPublishedAt != nil {
+			t.Errorf("Expected nil LastPublishedAt for migrated source %s, got %v", src.Title, src.LastPublishedAt)
+		}
+	}
+
+	// Test updating LastPublishedAt
+	updateTime := time.Now()
+	sources[0].LastPublishedAt = &updateTime
+	if err := db.Save(&sources[0]).Error; err != nil {
+		t.Fatalf("Failed to update source with LastPublishedAt: %v", err)
+	}
+
+	// Verify the update
+	var updatedSource model.Source
+	if err := db.First(&updatedSource, sources[0].ID).Error; err != nil {
+		t.Fatalf("Failed to query updated source: %v", err)
+	}
+
+	if updatedSource.LastPublishedAt == nil {
+		t.Fatal("LastPublishedAt should not be nil after update")
+	}
+
+	if !updatedSource.LastPublishedAt.Equal(updateTime) {
+		t.Errorf("Expected LastPublishedAt to be %v, got %v", updateTime, *updatedSource.LastPublishedAt)
+	}
+}
+
+func TestSourceStorage_NewInstallation_HasLastPublishedAt(t *testing.T) {
+	// Test that new installations create the table with LastPublishedAt field
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+
+	storage := NewSourceStorageImpl(db)
+	if err := storage.Init(context.Background()); err != nil {
+		t.Fatalf("Failed to initialize storage: %v", err)
+	}
+
+	// Verify the column exists
+	sqlDB, _ := db.DB()
+	var columnCount int
+	err = sqlDB.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('sources')
+		WHERE name = 'last_published_at'
+	`).Scan(&columnCount)
+	if err != nil {
+		t.Fatalf("Failed to check column existence: %v", err)
+	}
+	if columnCount != 1 {
+		t.Fatal("last_published_at column should exist in new installation")
+	}
+
+	// Insert a source with LastPublishedAt
+	now := time.Now()
+	source := &model.Source{
+		Link:            "http://example.com/feed",
+		Title:           "Test Feed",
+		ErrorCount:      0,
+		LastPublishedAt: &now,
+	}
+
+	if err := storage.AddSource(context.Background(), source); err != nil {
+		t.Fatalf("Failed to add source: %v", err)
+	}
+
+	// Retrieve and verify
+	retrieved, err := storage.GetSource(context.Background(), source.ID)
+	if err != nil {
+		t.Fatalf("Failed to get source: %v", err)
+	}
+
+	if retrieved.LastPublishedAt == nil {
+		t.Fatal("LastPublishedAt should not be nil")
+	}
+
+	if !retrieved.LastPublishedAt.Equal(now) {
+		t.Errorf("Expected LastPublishedAt to be %v, got %v", now, *retrieved.LastPublishedAt)
+	}
+}


### PR DESCRIPTION
## Summary
- Add functionality to sort RSS subscriptions by their last published date
- Display the last published timestamp in the subscription list

## Changes
- Added `LastPublishedAt` field to the Source model to track when feeds were last updated
- Modified RSS parser to extract feed update timestamps (UpdatedParsed/PublishedParsed)
- Updated RSS scheduler to persist LastPublishedAt when checking feeds
- Enhanced subscription list to:
  - Sort feeds by most recently published first
  - Display last published date in "YYYY-MM-DD HH:MM:SS" format
  - Show "N/A" for feeds without publish dates (placed at end of list)
- Added comprehensive unit tests for the sorting functionality

## Test plan
- [x] Unit tests pass for sorting logic
- [x] Verified empty subscription list handling
- [x] Tested with feeds that have nil LastPublishedAt values
- [ ] Manual testing with real RSS feeds
- [ ] Verify database migration for existing installations

🤖 Generated with [Claude Code](https://claude.ai/code)